### PR TITLE
Remove co-author from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-/.git-coauthor
 .eslintcache
 /dist


### PR DESCRIPTION
Keep those files in .git (eg .git/COMMIT_TEMPLATE) so you don't get trolled by `git clean -fdx`.
